### PR TITLE
Closes #48

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -16,6 +16,8 @@ if [[ ! -v SUBSHELL_CMD ]]; then
   set -o errtrace
   set -o pipefail
   export SHELLOPTS
+  shopt -s inherit_errexit
+  export BASHOPTS
 fi
 
 ignore() {


### PR DESCRIPTION
Enable `shopt -s inherit_errexit` so that subshells (not test.sh subshells
initiated by subshell()) execute in errexit context.

Export `BASHOPTS` to propagate this option to test.sh subshells.