### PR TITLE
Closes #63: run_test_script: interpret relative paths from the callin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,9 @@ Otherwise a file named 'test.sh.config' will be searched in these locations (see
 
 Boolean variables are considered true when not empty and false otherwise (undefined or empty).
 
-Available configuration variables:
+The configuration is read before any configuration variable takes effect. The means that
+errors are displayed in the main output because the redirection to LOG_FILE has not been done yet.
+For the same reason, no color is applied: the COLOR configuration has not been yet processed.
 
 * VERBOSE
 
@@ -465,6 +467,13 @@ Available configuration variables:
 
   A regular expression that is matched against function names to discover test functions in managed mode.
   It is evaluated by grep.
+
+* COLOR
+
+  Values: yes, no. Default: yes.
+
+  * yes: output ANSI color escape sequences in both main and log output.
+  * no: do not output ANSI color escape sequences in neither main or log output.
 
 * LOG_DIR_NAME
 
@@ -664,10 +673,19 @@ This is the list of functions defined by test.sh that you can use in a test scri
   run_test_script <test script>
   ```
 
-  Executes \<test script\>, which is a standalone test.sh-enabled test script. Using this function is
-  preferred over plain execution of the test script because it resets internal variables that govern the
-  execution of test.sh and might affect the executed script. The current configuration of the calling script
-  is passed to the executed script. The main output of the executed script is directed to the log file of
+  Executes \<test script\>, which is a relative or absolute path to a standalone test.sh-enabled test script.
+  Relative paths are interpreted from `$TEST_SCRIPT_DIR`.
+
+  Using this function is preferred over plain execution of the test script because it resets internal
+  variables that govern the execution of test.sh and might affect the executed script. The current
+  configuration of the calling script is passed to the executed script, with the following exceptions:
+
+  * The current color settings (not the COLOR configuration variable) are reset.
+  * LOG_DIR_NAME, LOG_DIR, LOG_NAME and LOG_FILE: these variables are reset to the value they had at the start
+  of the calling script. Directing the called script log output to the calling script log file is not supported.
+  These variables can only be set in the called script or in its configuration file.
+
+  The main output of the executed script is directed to the log file of
   the calling script unless redirected elsewhere. For example, to redirect the main output of the executed
   script to the main output of the calling script, execute:
 

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 @LICENSE@
 #
@@ -151,7 +152,7 @@ call_teardown() {
 }
 
 run_test_script() {
-  local test_script=$1
+  local test_script=$(pwd=$PWD; cd "$TEST_SCRIPT_DIR"; realpath --relative-to "$pwd" "$1")
   shift
   ( unset \
       CURRENT_TEST_NAME \

--- a/test/Makefile
+++ b/test/Makefile
@@ -18,7 +18,8 @@ TESTS ?= \
     test_regression_30.sh \
     test_regression_31.sh \
     test_validate_values_56.sh \
-    test_config_LOG_vars_50.sh
+    test_config_LOG_vars_50.sh \
+    test_run_test_script.sh
 
 include Makefile.test
 

--- a/test/do_test_run_test_script.sh
+++ b/test/do_test_run_test_script.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+source "$(dirname "$(readlink -f "$0")")"/../test.sh
+
+echo lorem ipsum

--- a/test/test_REENTER.sh
+++ b/test/test_REENTER.sh
@@ -16,9 +16,9 @@ start_test "Subshells should not resource files when REENTER is false"
 assert_true '[[ $CHECK = pass ]]'
 
 start_test "Errors in subshells when REENTER is false should generate stack traces"
-! COLOR=no run_test_script "$TEST_SCRIPT_DIR"/do_test_REENTER.sh || { COLOR=yes; false; }
+! COLOR=no run_test_script do_test_REENTER.sh || { COLOR=yes; false; }
 COLOR=yes
-OUT="$TEST_SCRIPT_DIR"/testout/do_test_REENTER.sh.out
+OUT=$LOG_DIR/do_test_REENTER.sh.out
 grep "(environment:0)" "$OUT"
 OUT2="$TEST_SCRIPT_DIR"/.do_test_REENTER.out
 sed -e 's/^\(.*\)(.*)\(.*\)$/\1()\2/' "$OUT" >"$OUT2"

--- a/test/test_STACK_TRACE.sh
+++ b/test/test_STACK_TRACE.sh
@@ -12,17 +12,17 @@ start_test "STACK_TRACE should accept only valid values"
 )
 
 start_test "When STACK_TRACE=no no stack traces should be produced"
-! STACK_TRACE=no run_test_script "$TEST_SCRIPT_DIR"/do_test_STACK_TRACE.sh || false
+! STACK_TRACE=no run_test_script do_test_STACK_TRACE.sh || false
 ! grep '[test.sh].*  at ' "$OUT" || false
 
 start_test "When STACK_TRACE=pruned the stack traces should be truncated before the first test.sh frame"
-! STACK_TRACE=pruned run_test_script "$TEST_SCRIPT_DIR"/do_test_STACK_TRACE.sh || false
+! STACK_TRACE=pruned run_test_script do_test_STACK_TRACE.sh || false
 ! grep '[test.sh].*  at .*(.*test.sh:[0-9]*)' "$OUT" || false
 
 start_test "When STACK_TRACE=compact the stack traces should not contain frames in test.sh"
-! STACK_TRACE=compact run_test_script "$TEST_SCRIPT_DIR"/do_test_STACK_TRACE.sh || false
+! STACK_TRACE=compact run_test_script do_test_STACK_TRACE.sh || false
 ! grep '[test.sh].*  at .*(.*test.sh:[0-9]*)' "$OUT" || false
 
 start_test "When STACK_TRACE=full the stack traces should contain the complete call stack"
-! STACK_TRACE=full run_test_script "$TEST_SCRIPT_DIR"/do_test_STACK_TRACE.sh || false
+! STACK_TRACE=full run_test_script do_test_STACK_TRACE.sh || false
 grep '[test.sh].*  at .*(.*test.sh:[0-9]*)' "$OUT" || false

--- a/test/test_SUBSHELL.sh
+++ b/test/test_SUBSHELL.sh
@@ -15,7 +15,7 @@ start_test "SUBSHELL should accept only valid values"
 )
 
 start_test "When SUBSHELL=never teardown functions should be called"
-SUBSHELL=never run_test_script "$TEST_SCRIPT_DIR"/do_test_SUBSHELL.sh
+SUBSHELL=never run_test_script do_test_SUBSHELL.sh
 OUTFILE="$LOG_DIR"/do_test_SUBSHELL.sh.out
 OUTFILE2="$TEST_SCRIPT_DIR"/.do_test_SUBSHELL.out
 grep -v '\[test\.sh\]' "$OUTFILE" >"$OUTFILE2"
@@ -27,7 +27,7 @@ EOF
 rm "$OUTFILE2"
 
 start_test "When SUBSHELL=never a failure in teardown_test should not terminate the test with failure"
-SUBSHELL=never run_test_script "$TEST_SCRIPT_DIR"/do_test_SUBSHELL.sh teardown_test
+SUBSHELL=never run_test_script do_test_SUBSHELL.sh teardown_test
 OUTFILE="$LOG_DIR"/do_test_SUBSHELL.sh.out
 OUTFILE2="$TEST_SCRIPT_DIR"/.do_test_SUBSHELL.out
 grep -v '\[test\.sh\]' "$OUTFILE" >"$OUTFILE2"
@@ -39,7 +39,7 @@ EOF
 rm "$OUTFILE2"
 
 start_test "When SUBSHELL=never a failure in teardown_test_suite should terminate the test with failure"
-SUBSHELL=never run_test_script "$TEST_SCRIPT_DIR"/do_test_SUBSHELL.sh teardown_test_suite
+SUBSHELL=never run_test_script do_test_SUBSHELL.sh teardown_test_suite
 OUTFILE="$LOG_DIR"/do_test_SUBSHELL.sh.out
 OUTFILE2="$TEST_SCRIPT_DIR"/.do_test_SUBSHELL.out
 grep -v '\[test\.sh\]' "$OUTFILE" >"$OUTFILE2"
@@ -51,7 +51,7 @@ EOF
 rm "$OUTFILE2"
 
 start_test "When SUBSHELL=teardown teardown functions should be called"
-SUBSHELL=teardown run_test_script "$TEST_SCRIPT_DIR"/do_test_SUBSHELL.sh
+SUBSHELL=teardown run_test_script do_test_SUBSHELL.sh
 OUTFILE="$LOG_DIR"/do_test_SUBSHELL.sh.out
 OUTFILE2="$TEST_SCRIPT_DIR"/.do_test_SUBSHELL.out
 grep -v '\[test\.sh\]' "$OUTFILE" >"$OUTFILE2"
@@ -63,7 +63,7 @@ EOF
 rm "$OUTFILE2"
 
 start_test "When SUBSHELL=teardown a failure in teardown_test should not terminate the test with failure"
-SUBSHELL=teardown run_test_script "$TEST_SCRIPT_DIR"/do_test_SUBSHELL.sh teardown_test
+SUBSHELL=teardown run_test_script do_test_SUBSHELL.sh teardown_test
 OUTFILE="$LOG_DIR"/do_test_SUBSHELL.sh.out
 OUTFILE2="$TEST_SCRIPT_DIR"/.do_test_SUBSHELL.out
 grep -v '\[test\.sh\]' "$OUTFILE" >"$OUTFILE2"
@@ -75,7 +75,7 @@ EOF
 rm "$OUTFILE2"
 
 start_test "When SUBSHELL=teardown a failure in teardown_test_suite should not terminate the test with failure"
-SUBSHELL=teardown run_test_script "$TEST_SCRIPT_DIR"/do_test_SUBSHELL.sh teardown_test_suite
+SUBSHELL=teardown run_test_script do_test_SUBSHELL.sh teardown_test_suite
 OUTFILE="$LOG_DIR"/do_test_SUBSHELL.sh.out
 OUTFILE2="$TEST_SCRIPT_DIR"/.do_test_SUBSHELL.out
 grep -v '\[test\.sh\]' "$OUTFILE" >"$OUTFILE2"

--- a/test/test_assert.sh
+++ b/test/test_assert.sh
@@ -29,4 +29,4 @@ start_test "assert_equals shoud fail when the arguments are not equal"
 ( ! REENTER=  subshell "assert_equals expected current wrong" || false )
 
 start_test "Failed assertions should interrupt the test when FAIL_FAST is true"
-( ! REENTER=1 run_test_script "$TEST_SCRIPT_DIR"/do_test_assert_nosubshell.sh || false )
+( ! REENTER=1 run_test_script do_test_assert_nosubshell.sh || false )

--- a/test/test_config_LOG_vars_50.sh
+++ b/test/test_config_LOG_vars_50.sh
@@ -3,7 +3,7 @@
 source "$(dirname "$(readlink -f "$0")")"/../test.sh
 
 start_test "LOG_DIR_NANME"
-run_test_script "$TEST_SCRIPT_DIR"/do_test_config_LOG_vars.sh "LOG_DIR_NAME=config_LOG_vars"
+run_test_script do_test_config_LOG_vars.sh "LOG_DIR_NAME=config_LOG_vars"
 LOG=$TEST_SCRIPT_DIR/config_LOG_vars/do_test_config_LOG_vars.sh.out
 diff - "$LOG" <<EOF
 lorem ipsum
@@ -11,7 +11,7 @@ EOF
 rm "$LOG"
 
 start_test "LOG_DIR"
-run_test_script "$TEST_SCRIPT_DIR"/do_test_config_LOG_vars.sh 'LOG_DIR="$TEST_SCRIPT_DIR"/config_LOG_vars'
+run_test_script do_test_config_LOG_vars.sh 'LOG_DIR="$TEST_SCRIPT_DIR"/config_LOG_vars'
 LOG=$TEST_SCRIPT_DIR/config_LOG_vars/do_test_config_LOG_vars.sh.out
 diff - "$LOG" <<EOF
 lorem ipsum
@@ -19,7 +19,7 @@ EOF
 rm "$LOG"
 
 start_test "LOG_NAME"
-run_test_script "$TEST_SCRIPT_DIR"/do_test_config_LOG_vars.sh 'LOG_NAME=config_LOG_vars.log'
+run_test_script do_test_config_LOG_vars.sh 'LOG_NAME=config_LOG_vars.log'
 LOG=$TEST_SCRIPT_DIR/$LOG_DIR_NAME/config_LOG_vars.log
 diff - "$LOG" <<EOF
 lorem ipsum
@@ -27,7 +27,7 @@ EOF
 rm "$LOG"
 
 start_test "LOG_FILE"
-run_test_script "$TEST_SCRIPT_DIR"/do_test_config_LOG_vars.sh 'LOG_FILE=/tmp/config_LOG_vars.log'
+run_test_script do_test_config_LOG_vars.sh 'LOG_FILE=/tmp/config_LOG_vars.log'
 LOG=/tmp/config_LOG_vars.log
 diff - "$LOG" <<EOF
 lorem ipsum
@@ -35,12 +35,12 @@ EOF
 rm "$LOG"
 
 start_test "LOG_MODE"
-run_test_script "$TEST_SCRIPT_DIR"/do_test_config_LOG_vars.sh 'LOG_MODE=overwrite'
+run_test_script do_test_config_LOG_vars.sh 'LOG_MODE=overwrite'
 LOG=$TEST_SCRIPT_DIR/testout/do_test_config_LOG_vars.sh.out
 diff - "$LOG" <<EOF
 lorem ipsum
 EOF
-run_test_script "$TEST_SCRIPT_DIR"/do_test_config_LOG_vars.sh 'LOG_MODE=append'
+run_test_script do_test_config_LOG_vars.sh 'LOG_MODE=append'
 diff - "$LOG" <<EOF
 lorem ipsum
 lorem ipsum

--- a/test/test_error_reporting.sh
+++ b/test/test_error_reporting.sh
@@ -4,125 +4,125 @@ source "$(dirname "$(readlink -f "$0")")"/../test.sh
 OUT="$LOG_DIR"/do_$(basename "$LOG_FILE")
 
 start_test "The error message should identify the source, line, command and exit code when there are no subshells"
-! SUBSHELL=never run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [func2] || false
+! SUBSHELL=never run_test_script do_test_error_reporting.sh [func2] || false
 grep "Error in func2(do_test_error_reporting.sh:8): 'false' exited with status 1" "$OUT"
-! SUBSHELL=never run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [func1] || false
+! SUBSHELL=never run_test_script do_test_error_reporting.sh [func1] || false
 grep "Error in func1(do_test_error_reporting.sh:3): 'false' exited with status 1" "$OUT"
-! SUBSHELL=never run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [test_01] || false
+! SUBSHELL=never run_test_script do_test_error_reporting.sh [test_01] || false
 grep "Error in test_01(do_test_error_reporting.sh:13): 'false' exited with status 1" "$OUT"
 
 start_test "The error message should identify the source, line, command and exit code when there are subshells"
-! SUBSHELL=always run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [func2] || false
+! SUBSHELL=always run_test_script do_test_error_reporting.sh [func2] || false
 grep "Error in func2(do_test_error_reporting.sh:8): 'false' exited with status 1" "$OUT"
-! SUBSHELL=always run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [func1] || false
+! SUBSHELL=always run_test_script do_test_error_reporting.sh [func1] || false
 grep "Error in func1(do_test_error_reporting.sh:3): 'false' exited with status 1" "$OUT"
-! SUBSHELL=always run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [test_01] || false
+! SUBSHELL=always run_test_script do_test_error_reporting.sh [test_01] || false
 grep "Error in test_01(do_test_error_reporting.sh:13): 'false' exited with status 1" "$OUT"
 
 start_test "The error message should identify the source, line, command and exit code when triggered in teardown_test"
-SUBSHELL=never    INLINE=     run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [teardown_test]
+SUBSHELL=never    INLINE=     run_test_script do_test_error_reporting.sh [teardown_test]
 grep "Error in teardown_test(do_test_error_reporting.sh:18): 'false' exited with status 1" "$OUT"
 [[ $(grep "Error in teardown_test(do_test_error_reporting.sh:18): '.*' exited with status 1" "$OUT" | wc -l) = 1 ]]
-SUBSHELL=teardown INLINE=     run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [teardown_test]
+SUBSHELL=teardown INLINE=     run_test_script do_test_error_reporting.sh [teardown_test]
 grep "Error in teardown_test(do_test_error_reporting.sh:18): 'false' exited with status 1" "$OUT"
 [[ $(grep "Error in teardown_test(do_test_error_reporting.sh:18): '.*' exited with status 1" "$OUT" | wc -l) = 1 ]]
-SUBSHELL=never    INLINE=true run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [teardown_test]
+SUBSHELL=never    INLINE=true run_test_script do_test_error_reporting.sh [teardown_test]
 grep "Error in teardown_test(do_test_error_reporting.sh:18): 'false' exited with status 1" "$OUT"
 [[ $(grep "Error in teardown_test(do_test_error_reporting.sh:18): '.*' exited with status 1" "$OUT" | wc -l) = 2 ]]
-SUBSHELL=teardown INLINE=true run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [teardown_test]
+SUBSHELL=teardown INLINE=true run_test_script do_test_error_reporting.sh [teardown_test]
 grep "Error in teardown_test(do_test_error_reporting.sh:18): 'false' exited with status 1" "$OUT"
 [[ $(grep "Error in teardown_test(do_test_error_reporting.sh:18): '.*' exited with status 1" "$OUT" | wc -l) = 2 ]]
 
 start_test "The error message should identify the source, line, command and exit code when triggered in teardown_test_suite"
-SUBSHELL=never    INLINE=     run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [teardown_test_suite]
+SUBSHELL=never    INLINE=     run_test_script do_test_error_reporting.sh [teardown_test_suite]
 grep "Error in teardown_test_suite(do_test_error_reporting.sh:23): 'false' exited with status 1" "$OUT"
-SUBSHELL=teardown INLINE=     run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [teardown_test_suite]
+SUBSHELL=teardown INLINE=     run_test_script do_test_error_reporting.sh [teardown_test_suite]
 grep "Error in teardown_test_suite(do_test_error_reporting.sh:23): 'false' exited with status 1" "$OUT"
-SUBSHELL=never    INLINE=true run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [teardown_test_suite]
+SUBSHELL=never    INLINE=true run_test_script do_test_error_reporting.sh [teardown_test_suite]
 # aparente error en bash: el comando reportado pasa a ser '[[ $FAIL_FUNC != $FUNCNAME ]]' en lugar de 'false'
 grep "Error in teardown_test_suite(do_test_error_reporting.sh:23): '.*' exited with status 1" "$OUT"
-SUBSHELL=teardown INLINE=true run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [teardown_test_suite]
+SUBSHELL=teardown INLINE=true run_test_script do_test_error_reporting.sh [teardown_test_suite]
 grep "Error in teardown_test_suite(do_test_error_reporting.sh:23): 'false' exited with status 1" "$OUT"
 
 start_test "The error message should identify the source, line, command and exit code when triggered in assert"
-! SUBSHELL=never  run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [func_assert] || false
+! SUBSHELL=never  run_test_script do_test_error_reporting.sh [func_assert] || false
 grep "Error in expect_true(test.sh:.*): 'false' exited with status 1" "$OUT"
-! SUBSHELL=always STACK_TRACE=full run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [func_assert] || false
+! SUBSHELL=always STACK_TRACE=full run_test_script do_test_error_reporting.sh [func_assert] || false
 grep "Error in source(test.sh:.*): 'false' exited with status 1" "$OUT"
 
 start_test "The error message should identify the source, line, command and exit code when triggered in setup_test_suite"
-! SUBSHELL=never    INLINE=     run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [setup_test_suite] || false
+! SUBSHELL=never    INLINE=     run_test_script do_test_error_reporting.sh [setup_test_suite] || false
 grep "Error in setup_test_suite(do_test_error_reporting.sh:38): 'false' exited with status 1" "$OUT"
 [[ $(grep "Error in setup_test_suite(do_test_error_reporting.sh:38): '.*' exited with status 1" "$OUT" | wc -l) = 1 ]]
-! SUBSHELL=never    INLINE=true run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [setup_test_suite] || false
+! SUBSHELL=never    INLINE=true run_test_script do_test_error_reporting.sh [setup_test_suite] || false
 grep "Error in setup_test_suite(do_test_error_reporting.sh:38): 'false' exited with status 1" "$OUT"
 [[ $(grep "Error in setup_test_suite(do_test_error_reporting.sh:38): '.*' exited with status 1" "$OUT" | wc -l) = 1 ]]
 
 start_test "The error message should identify the source, line, command and exit code when triggered in setup_test"
-! SUBSHELL=never    INLINE=     run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [setup_test] || false
+! SUBSHELL=never    INLINE=     run_test_script do_test_error_reporting.sh [setup_test] || false
 grep "Error in setup_test(do_test_error_reporting.sh:33): 'false' exited with status 1" "$OUT"
 [[ $(grep "Error in setup_test(do_test_error_reporting.sh:33): '.*' exited with status 1" "$OUT" | wc -l) = 1 ]]
-! SUBSHELL=never    INLINE=true run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [setup_test] || false
+! SUBSHELL=never    INLINE=true run_test_script do_test_error_reporting.sh [setup_test] || false
 grep "Error in setup_test(do_test_error_reporting.sh:33): 'false' exited with status 1" "$OUT"
 [[ $(grep "Error in setup_test(do_test_error_reporting.sh:33): '.*' exited with status 1" "$OUT" | wc -l) = 1 ]]
 
 start_test "Teardown semantics should be enforced when both teardown_test and teardon_test_suite fail"
-SUBSHELL=never    INLINE=     run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [teardown_test][teardown_test_suite]
+SUBSHELL=never    INLINE=     run_test_script do_test_error_reporting.sh [teardown_test][teardown_test_suite]
 # aparente error en bash: el comando reportado pasa a ser '[[ $FAIL_FUNC != $FUNCNAME ]]' en lugar de 'false'
 grep "Error in teardown_test(do_test_error_reporting.sh:18): '.*' exited with status 1" "$OUT"
 grep "Error in teardown_test_suite(do_test_error_reporting.sh:23): '.*' exited with status 1" "$OUT"
 [[ $(grep "Error in teardown_test(do_test_error_reporting.sh:18): '.*' exited with status 1" "$OUT" | wc -l) = 1 ]]
-SUBSHELL=teardown INLINE=     run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [teardown_test][teardown_test_suite]
+SUBSHELL=teardown INLINE=     run_test_script do_test_error_reporting.sh [teardown_test][teardown_test_suite]
 grep "Error in teardown_test(do_test_error_reporting.sh:18): 'false' exited with status 1" "$OUT"
 grep "Error in teardown_test_suite(do_test_error_reporting.sh:23): 'false' exited with status 1" "$OUT"
 [[ $(grep "Error in teardown_test(do_test_error_reporting.sh:18): '.*' exited with status 1" "$OUT" | wc -l) = 1 ]]
-SUBSHELL=always   INLINE=     run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [teardown_test][teardown_test_suite]
+SUBSHELL=always   INLINE=     run_test_script do_test_error_reporting.sh [teardown_test][teardown_test_suite]
 grep "Error in teardown_test(do_test_error_reporting.sh:18): 'false' exited with status 1" "$OUT"
 grep "Error in teardown_test_suite(do_test_error_reporting.sh:23): 'false' exited with status 1" "$OUT"
 [[ $(grep "Error in teardown_test(do_test_error_reporting.sh:18): '.*' exited with status 1" "$OUT" | wc -l) = 1 ]]
-SUBSHELL=never    INLINE=true run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [teardown_test][teardown_test_suite]
+SUBSHELL=never    INLINE=true run_test_script do_test_error_reporting.sh [teardown_test][teardown_test_suite]
 # aparente error en bash: el comando reportado pasa a ser '[[ $FAIL_FUNC != $FUNCNAME ]]' en lugar de 'false'
 grep "Error in teardown_test(do_test_error_reporting.sh:18): '.*' exited with status 1" "$OUT"
 grep "Error in teardown_test_suite(do_test_error_reporting.sh:23): '.*' exited with status 1" "$OUT"
 [[ $(grep "Error in teardown_test(do_test_error_reporting.sh:18): '.*' exited with status 1" "$OUT" | wc -l) = 2 ]]
-SUBSHELL=teardown INLINE=true run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [teardown_test][teardown_test_suite]
+SUBSHELL=teardown INLINE=true run_test_script do_test_error_reporting.sh [teardown_test][teardown_test_suite]
 grep "Error in teardown_test(do_test_error_reporting.sh:18): 'false' exited with status 1" "$OUT"
 grep "Error in teardown_test_suite(do_test_error_reporting.sh:23): 'false' exited with status 1" "$OUT"
 [[ $(grep "Error in teardown_test(do_test_error_reporting.sh:18): '.*' exited with status 1" "$OUT" | wc -l) = 2 ]]
-SUBSHELL=always   INLINE=true run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [teardown_test][teardown_test_suite]
+SUBSHELL=always   INLINE=true run_test_script do_test_error_reporting.sh [teardown_test][teardown_test_suite]
 grep "Error in teardown_test(do_test_error_reporting.sh:18): 'false' exited with status 1" "$OUT"
 grep "Error in teardown_test_suite(do_test_error_reporting.sh:23): 'false' exited with status 1" "$OUT"
 [[ $(grep "Error in teardown_test(do_test_error_reporting.sh:18): '.*' exited with status 1" "$OUT" | wc -l) = 2 ]]
 
 start_test "Teardown semantics should be enforced when the test, teardown_test and teardon_test_suite fail"
-! SUBSHELL=never    INLINE=     run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [test_01][teardown_test][teardown_test_suite] || false
+! SUBSHELL=never    INLINE=     run_test_script do_test_error_reporting.sh [test_01][teardown_test][teardown_test_suite] || false
 grep "Error in test_01(do_test_error_reporting.sh:13): 'false' exited with status 1" "$OUT"
 # aparente error en bash: el comando reportado pasa a ser '[[ $FAIL_FUNC != $FUNCNAME ]]' en lugar de 'false'
 grep "Error in teardown_test(do_test_error_reporting.sh:18): '.*' exited with status 1" "$OUT"
 grep "Error in teardown_test_suite(do_test_error_reporting.sh:23): '.*' exited with status 1" "$OUT"
 [[ $(grep "Error in teardown_test(do_test_error_reporting.sh:18): '.*' exited with status 1" "$OUT" | wc -l) = 1 ]]
-! SUBSHELL=teardown INLINE=     run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [test_01][teardown_test][teardown_test_suite] || false
+! SUBSHELL=teardown INLINE=     run_test_script do_test_error_reporting.sh [test_01][teardown_test][teardown_test_suite] || false
 grep "Error in test_01(do_test_error_reporting.sh:13): 'false' exited with status 1" "$OUT"
 grep "Error in teardown_test(do_test_error_reporting.sh:18): 'false' exited with status 1" "$OUT"
 grep "Error in teardown_test_suite(do_test_error_reporting.sh:23): 'false' exited with status 1" "$OUT"
 [[ $(grep "Error in teardown_test(do_test_error_reporting.sh:18): '.*' exited with status 1" "$OUT" | wc -l) = 1 ]]
-! SUBSHELL=always   INLINE=     run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [test_01][teardown_test][teardown_test_suite] || false
+! SUBSHELL=always   INLINE=     run_test_script do_test_error_reporting.sh [test_01][teardown_test][teardown_test_suite] || false
 grep "Error in test_01(do_test_error_reporting.sh:13): 'false' exited with status 1" "$OUT"
 grep "Error in teardown_test(do_test_error_reporting.sh:18): 'false' exited with status 1" "$OUT"
 grep "Error in teardown_test_suite(do_test_error_reporting.sh:23): 'false' exited with status 1" "$OUT"
 [[ $(grep "Error in teardown_test(do_test_error_reporting.sh:18): '.*' exited with status 1" "$OUT" | wc -l) = 1 ]]
-! SUBSHELL=never    INLINE=true run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [test_01][teardown_test][teardown_test_suite] || false
+! SUBSHELL=never    INLINE=true run_test_script do_test_error_reporting.sh [test_01][teardown_test][teardown_test_suite] || false
 grep "Error in test_01(do_test_error_reporting.sh:13): 'false' exited with status 1" "$OUT"
 # aparente error en bash: el comando reportado pasa a ser '[[ $FAIL_FUNC != $FUNCNAME ]]' en lugar de 'false'
 grep "Error in teardown_test(do_test_error_reporting.sh:18): '.*' exited with status 1" "$OUT"
 grep "Error in teardown_test_suite(do_test_error_reporting.sh:23): '.*' exited with status 1" "$OUT"
 [[ $(grep "Error in teardown_test(do_test_error_reporting.sh:18): '.*' exited with status 1" "$OUT" | wc -l) = 1 ]]
-! SUBSHELL=teardown INLINE=true run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [test_01][teardown_test][teardown_test_suite] || false
+! SUBSHELL=teardown INLINE=true run_test_script do_test_error_reporting.sh [test_01][teardown_test][teardown_test_suite] || false
 grep "Error in test_01(do_test_error_reporting.sh:13): 'false' exited with status 1" "$OUT"
 grep "Error in teardown_test(do_test_error_reporting.sh:18): 'false' exited with status 1" "$OUT"
 grep "Error in teardown_test_suite(do_test_error_reporting.sh:23): 'false' exited with status 1" "$OUT"
 [[ $(grep "Error in teardown_test(do_test_error_reporting.sh:18): '.*' exited with status 1" "$OUT" | wc -l) = 1 ]]
-! SUBSHELL=always   INLINE=true run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [test_01][teardown_test][teardown_test_suite] || false
+! SUBSHELL=always   INLINE=true run_test_script do_test_error_reporting.sh [test_01][teardown_test][teardown_test_suite] || false
 grep "Error in test_01(do_test_error_reporting.sh:13): 'false' exited with status 1" "$OUT"
 grep "Error in teardown_test(do_test_error_reporting.sh:18): 'false' exited with status 1" "$OUT"
 grep "Error in teardown_test_suite(do_test_error_reporting.sh:23): 'false' exited with status 1" "$OUT"

--- a/test/test_ignored.sh
+++ b/test/test_ignored.sh
@@ -5,6 +5,6 @@ FILES_DIR=$TEST_SCRIPT_DIR/files
 
 start_test "In managed mode and SUBSHELL=always when a test fails the remaining tests should be displayed as skipped in the main output"
 OUT=$TEST_SCRIPT_DIR/.test_script.out
-! FAIL_FAST=1 SUBSHELL=always run_test_script "$TEST_SCRIPT_DIR"/do_test_ignored.sh >"$OUT" || false
+! FAIL_FAST=1 SUBSHELL=always run_test_script do_test_ignored.sh >"$OUT" || false
 diff "$FILES_DIR"/test_ignored.out "$OUT"
 rm -f "$OUT"

--- a/test/test_includes.sh
+++ b/test/test_includes.sh
@@ -47,6 +47,6 @@ INCLUDE_PATH="$TEST_SCRIPT_DIR"/files/_include*.sh
 
 TEARDOWN_PREFIX=$SETUP_PREFIX
 start_test "Included files should not be reported when reincluded"
-INCLUDE_PATH="$TEST_SCRIPT_DIR"/files/_include*.sh run_test_script "$TEST_SCRIPT_DIR"/do_test_includes.sh
+INCLUDE_PATH="$TEST_SCRIPT_DIR"/files/_include*.sh run_test_script do_test_includes.sh
 OUT="$TEST_SCRIPT_DIR"/testout/do_test_includes.sh.out
 assert_equals 2 "$(grep "\[test.sh\].* Included:" "$OUT" | wc -l)" "wrong count"

--- a/test/test_inline.sh
+++ b/test/test_inline.sh
@@ -5,7 +5,7 @@ OUTFILE="$TEST_SCRIPT_DIR"/.test_inline.out
 
 start_test "Inline test failures should display the failed test in the main output"
 OUT="$TEST_SCRIPT_DIR"/.do_test_inline.sh.main.out
-( ! COLOR=no run_test_script "$TEST_SCRIPT_DIR"/do_test_inline.sh >"$OUT" 2>&1 || false )
+( ! COLOR=no run_test_script do_test_inline.sh >"$OUT" 2>&1 || false )
 diff - "$OUT" <<EOF
 * do_test_inline ok
 * do_test_inline fail
@@ -14,7 +14,7 @@ rm "$OUT"
 rm "$OUTFILE"
 
 start_test "Inline tests should invoke setup and teardown functions"
-! run_test_script "$TEST_SCRIPT_DIR"/do_test_inline.sh || false
+! run_test_script do_test_inline.sh || false
 diff - "$OUTFILE" <<EOF
 setup_test_suite
 setup_test

--- a/test/test_log.sh
+++ b/test/test_log.sh
@@ -3,8 +3,8 @@ source "$(dirname "$(readlink -f "$0")")"/../test.sh
 
 start_test "The log file should contain test stdout and stderr"
 # run in a different test script to avoid the race condition on the log output
-! run_test_script "$TEST_SCRIPT_DIR"/do_test_log.sh || false
-OUT="$TEST_SCRIPT_DIR"/testout/do_test_log.sh.out
+! run_test_script do_test_log.sh || false
+OUT=$LOG_DIR/do_test_log.sh.out
 grep ^output$ "$OUT"
 grep ^stderr$ "$OUT"
 

--- a/test/test_regression_33.sh
+++ b/test/test_regression_33.sh
@@ -15,6 +15,6 @@ chmod a+x "$TEST_SCRIPT_DIR"/test-regression-33.sh
 cp "$TESTSH" "$TEST_SCRIPT_DIR"
 unset INCLUDE_GLOB
 unset INCLUDE_PATH
-( cd "$TEST_SCRIPT_DIR"; run_test_script ./test-regression-33.sh )
+( run_test_script ./test-regression-33.sh )
 assert_equals 1 "$(grep "regression #33" "$TEST_SCRIPT_DIR"/testout/test-regression-33.sh.out | wc -l)"
 rm "$TEST_SCRIPT_DIR"/include-regression-33.sh "$TEST_SCRIPT_DIR"/test-regression-33.sh "$TEST_SCRIPT_DIR"/test.sh

--- a/test/test_run_test_script.sh
+++ b/test/test_run_test_script.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+source "$(dirname "$(readlink -f "$0")")"/../test.sh
+
+COMPANION_TEST_NAME=do_$(basename "$TEST_SCRIPT")
+COMPANION_TEST_SCRIPT=$TEST_SCRIPT_DIR/$COMPANION_TEST_NAME
+
+start_test "run_test_script() interprets relative paths from the current script (#63)"
+( cd ..; run_test_script $COMPANION_TEST_NAME )
+diff - "$LOG_DIR"/"$COMPANION_TEST_NAME".out <<EOF
+lorem ipsum
+EOF

--- a/test/test_setup_error.sh
+++ b/test/test_setup_error.sh
@@ -5,17 +5,17 @@ OUT=$TEST_SCRIPT_DIR/.test_setup_error.sh.out
 FILES_DIR=$TEST_SCRIPT_DIR/files
 
 start_test "When setup_test_suite fails, an error message should be displayed in the main output"
-! INLINE=     run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [setup_test_suite] >"$OUT" 2>&1 || false
+! INLINE=     run_test_script do_test_error_reporting.sh [setup_test_suite] >"$OUT" 2>&1 || false
 diff "$FILES_DIR"/test_setup_error.1.out "$OUT"
 rm -f "$OUT"
-! INLINE=true run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [setup_test_suite] >"$OUT" 2>&1 || false
+! INLINE=true run_test_script do_test_error_reporting.sh [setup_test_suite] >"$OUT" 2>&1 || false
 diff "$FILES_DIR"/test_setup_error.1.out "$OUT"
 rm -f "$OUT"
 
 start_test "When setup_test fails a failed test error message should be displayed in the main output"
-! INLINE=     run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [setup_test] >"$OUT" 2>&1 || false
+! INLINE=     run_test_script do_test_error_reporting.sh [setup_test] >"$OUT" 2>&1 || false
 diff "$FILES_DIR"/test_setup_error.2.out "$OUT"
 rm -f "$OUT"
-! INLINE=true run_test_script "$TEST_SCRIPT_DIR"/do_test_error_reporting.sh [setup_test] >"$OUT" 2>&1 || false
+! INLINE=true run_test_script do_test_error_reporting.sh [setup_test] >"$OUT" 2>&1 || false
 diff "$FILES_DIR"/test_setup_error.3.out "$OUT"
 rm -f "$OUT"

--- a/test/test_teardown_fail.sh
+++ b/test/test_teardown_fail.sh
@@ -2,15 +2,15 @@
 source "$(dirname "$(readlink -f "$0")")"/../test.sh
 
 start_test "Failing teardown functions should not break the test"
-run_test_script "$TEST_SCRIPT_DIR"/do_test_teardown_fail.sh
+run_test_script do_test_teardown_fail.sh
 
 start_test "Teardown functions should execute in errexit context"
-OUT="$TEST_SCRIPT_DIR"/testout/do_test_teardown_fail.sh.out
+OUT=$LOG_DIR/do_test_teardown_fail.sh.out
 assert_equals 0 "$(grep -c "never reached" "$OUT")" "teardown function in ignored errexit context"
 
 start_test "Teardown functions should print a warning in the main output when they fail"
 OUT="$TEST_SCRIPT_DIR"/.do_test_teardown_fail.sh.mainout
-( COLOR=no run_test_script "$TEST_SCRIPT_DIR"/do_test_teardown_fail.sh >"$OUT" )
+( COLOR=no run_test_script do_test_teardown_fail.sh >"$OUT" )
 diff - "$OUT" <<EOF
 * test_01
 WARN: teardown_test failed

--- a/test/test_validate_values_56.sh
+++ b/test/test_validate_values_56.sh
@@ -3,7 +3,7 @@ source "$(dirname "$(readlink -f "$0")")"/../test.sh
 
 start_test "validate_values() should print a comma-separated list of allowes values (#56)"
 OUT="$TEST_SCRIPT_DIR"/testout/do_test_validate_values.sh.out
-( ! STACK_TRACE=jeronimo COLOR=no run_test_script "$TEST_SCRIPT_DIR"/do_test_validate_values.sh >"$OUT" 2>&1 ) || false
+( ! STACK_TRACE=jeronimo COLOR=no run_test_script do_test_validate_values.sh >"$OUT" 2>&1 ) || false
 assert_equals \
   "[test.sh] Configuration: invalid value of variable STACK_TRACE: 'jeronimo', allowed values: no, full" \
   "$(grep -a "invalid value" "$OUT")" \


### PR DESCRIPTION
…g script

Other changes not related to this issue:

* Document COLOR configuration variable.
* Document the configuration flow and how it affects errors generated during
configuration parsing.