### PR TITLE
Closes #74: temporary files in TMPDIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,8 @@ The configuration is read before any configuration variable takes effect. The me
 errors are displayed in the main output because the redirection to LOG_FILE has not been done yet.
 For the same reason, no color is applied: the COLOR configuration has not been yet processed.
 
+Temporary files are created in TMPDIR if set, otherwise in `/tmp`.
+
 * VERBOSE
 
   Boolean. Default false.

--- a/test/Makefile
+++ b/test/Makefile
@@ -21,7 +21,10 @@ TESTS ?= \
     test_config_LOG_vars_50.sh \
     test_run_test_script_63.sh \
     test_assert_escaping_62.sh \
-    test_assert_71.sh
+    test_assert_71.sh \
+    test_tmpdir_74.sh \
+    \
+    test_xxx_tmpfiles_74.sh
 
 include Makefile.test
 

--- a/test/test_tmpdir_74.sh
+++ b/test/test_tmpdir_74.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+TMPDIR="$(dirname "$(readlink -f "$0")")"/tmp
+mkdir -p "$TMPDIR"
+source "$(dirname "$(readlink -f "$0")")"/../test.sh
+
+start_test "#74: Use TMPDIR for temporary files"
+save_stack
+TMPFILE_COUNT=$(find "$TMPDIR" -type f -o -type p | wc -l)
+rm -f "$STACK_FILE"
+assert_equals 2 "$TMPFILE_COUNT" "Expected two temporary files in $TMPDIR"
+rm -rf "$TMPDIR"

--- a/test/test_xxx_tmpfiles_74.sh
+++ b/test/test_xxx_tmpfiles_74.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+source "$(dirname "$(readlink -f "$0")")"/../test.sh
+
+start_test "#74: Ensure temporary files are cleaned after running all tests"
+set +e pipefail
+FILES=$({ find ${TMPDIR:-/tmp} -name tsh-\* 2>/dev/null || true; } | { grep -v "$TSH_TMPDIR" || true; } | { wc -l || true; })
+assert_equals 0 "$FILES" "Temporary files remain"


### PR DESCRIPTION
* Secure creation of fifo
* Common root for temporary files
* Use dirname of LOG_FILE instead of LOG_DIR to create the log directory