### PR TITLE
Fixes #76: assertion failures reevaluates the expression

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -337,10 +337,11 @@ assert_msg() {
 }
 
 assert_err_msg() {
-  log_err "$(assert_msg "$@")"
+  log_err "$(assert_msg "$tsh_assert_msg" "$tsh_assert_why")"
 }
 
-expect_true() {
+expect_true()
+{
   eval "$1"
 }
 
@@ -354,7 +355,9 @@ assert() {
   local why=$3
   local msg=$4
   shift
-  push_err_handler "pop_err_handler; assert_err_msg \"$msg\" \"$why\""
+  tsh_assert_msg=$msg
+  tsh_assert_why=$why
+  push_err_handler "pop_err_handler; assert_err_msg"
   if [[ $SUBSHELL == always ]]; then
     $expect "subshell $(printf "%q" "$what")"
   else
@@ -379,7 +382,12 @@ assert_equals() {
   local expected=$1
   local current=$2
   local msg=$3
-  assert "[[ \"$expected\" = \"$current\" ]]" expect_true "expected '$expected' but got '$current'" "$msg"
+  tsh_assert_msg=$msg
+  # TODO: dump exact value, avoid any bash processing
+  tsh_assert_why="[[ \"$expected\" = \"$current\" ]]"
+  push_err_handler "pop_err_handler; assert_err_msg"
+  [[ "$expected" = "$current" ]]
+  pop_err_handler
 }
 
 if [[ -v SUBSHELL_CMD ]]; then

--- a/test/Makefile
+++ b/test/Makefile
@@ -23,6 +23,7 @@ TESTS ?= \
     test_assert_escaping_62.sh \
     test_assert_71.sh \
     test_tmpdir_74.sh \
+    test_assert_76.sh \
     \
     test_xxx_tmpfiles_74.sh
 

--- a/test/test_assert_76.sh
+++ b/test/test_assert_76.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+my_func() {
+  echo called >"$OUT"
+}
+
+source "$(dirname "$(readlink -f "$0")")"/../test.sh
+
+OUT="$TEST_SCRIPT_DIR"/.test_assert_76.out
+
+start_test "#74: assert_equals never evaluates its arguments"
+rm -f "$OUT"
+assert_equals my_func my_func
+[[ ! -f "$OUT" ]]
+echo -n $(assert_equals 2 "\""'$(ls|wc -l)')
+# TODO: check that there's no eval parsing error
+
+start_test "#74: failures in assertion functions don't reevaluate the expression"
+rm -f "$OUT"
+subshell "assert_true \"! my_func\"" || true
+diff - "$OUT" <<EOF
+called
+EOF
+rm -f "$OUT"
+subshell "assert_false my_func" || true
+diff - "$OUT" <<EOF
+called
+EOF


### PR DESCRIPTION
Also, `assert_equals` never evaluates its arguments.