### PR TITLE
Fixes #98: error report in successful assert_false

### DIFF
--- a/test/files/do_test_assert_71.out
+++ b/test/files/do_test_assert_71.out
@@ -1,42 +1,47 @@
 [test.sh] Assertion failed: first, expected success but got failure in: 'false'
-[test.sh] Error in expect_true(test.sh:): 'false' exited with status 1
+[test.sh] Error in expect_true(test.sh:): '[[ $LAST_RESULT = 0 ]]' exited with status 1
 [test.sh]  at assert(test.sh:)
 [test.sh]  at assert_true(test.sh:)
+[test.sh]  at eval_trace(test.sh:)
 [test.sh]  at result_of(test.sh:)
 [test.sh]  at main(do_test_assert_71.sh:)
 [test.sh] Assertion failed: second, expected success but got failure in: 'false'
-[test.sh] Error in expect_true(test.sh:): 'false' exited with status 1
+[test.sh] Error in expect_true(test.sh:): '[[ $LAST_RESULT = 0 ]]' exited with status 1
 [test.sh]  at assert(test.sh:)
 [test.sh]  at assert_true(test.sh:)
+[test.sh]  at eval_trace(test.sh:)
 [test.sh]  at result_of(test.sh:)
 [test.sh]  at main(do_test_assert_71.sh:)
 [test.sh] Assertion failed: test_01, expected success but got failure in: 'false'
-[test.sh] Error in expect_true(test.sh:): 'false' exited with status 1
+[test.sh] Error in expect_true(test.sh:): '[[ $LAST_RESULT = 0 ]]' exited with status 1
 [test.sh]  at assert(test.sh:)
 [test.sh]  at assert_true(test.sh:)
 [test.sh]  at test_01(do_test_assert_71.sh:)
 [test.sh]  at run_test(test.sh:)
+[test.sh]  at eval_trace(test.sh:)
 [test.sh]  at result_of(test.sh:)
 [test.sh]  at run_tests(test.sh:)
 [test.sh]  at main(do_test_assert_71.sh:)
 [test.sh] FAILED: test_01
 [test.sh] Assertion failed: teardown_test, expected success but got failure in: 'false'
-[test.sh] Error in expect_true(test.sh:): 'false' exited with status 1
+[test.sh] Error in expect_true(test.sh:): '[[ $LAST_RESULT = 0 ]]' exited with status 1
 [test.sh]  at assert(test.sh:)
 [test.sh]  at assert_true(test.sh:)
 [test.sh]  at teardown_test(do_test_assert_71.sh:)
 [test.sh]  at call_if_exists(test.sh:)
 [test.sh]  at call_teardown(test.sh:)
+[test.sh]  at eval_trace(test.sh:)
 [test.sh]  at result_of(test.sh:)
 [test.sh]  at run_tests(test.sh:)
 [test.sh]  at main(do_test_assert_71.sh:)
 [test.sh] Assertion failed: teardown_test_suite, expected success but got failure in: 'false'
-[test.sh] Error in expect_true(test.sh:): 'false' exited with status 1
+[test.sh] Error in expect_true(test.sh:): '[[ $LAST_RESULT = 0 ]]' exited with status 1
 [test.sh]  at assert(test.sh:)
 [test.sh]  at assert_true(test.sh:)
 [test.sh]  at teardown_test_suite(do_test_assert_71.sh:)
 [test.sh]  at call_if_exists(test.sh:)
 [test.sh]  at call_teardown(test.sh:)
+[test.sh]  at eval_trace(test.sh:)
 [test.sh]  at result_of(test.sh:)
 [test.sh]  at run_tests(test.sh:)
 [test.sh]  at main(do_test_assert_71.sh:)

--- a/test/test_assert.sh
+++ b/test/test_assert.sh
@@ -9,7 +9,7 @@ source "$(dirname "$(readlink -f "$0")")"/../test.sh
 start_test "Assertions should not fail when the assertion succeeds"
 ( assert_true "true" )
 ( assert_false "false" )
-( assert_false "subshell fail_validation" )
+( assert_false "fail_validation" )
 ( assert_equals a a )
 
 start_test "assert_true should fail when the assertion is false"
@@ -34,3 +34,5 @@ rm -f "$OUT"
 assert_false ffail
 assert_false "[ -f \"$OUT\"" "The file should not have been created"
 rm -f "$OUT"
+
+start_test "#98: eval syntax errors in assert_false expression should reaise the error over the assertion"

--- a/test/test_error_reporting.sh
+++ b/test/test_error_reporting.sh
@@ -29,7 +29,7 @@ grep "Error in teardown_test_suite(do_test_error_reporting.sh:23): '.*' exited w
 
 start_test "The error message should identify the source, line, command and exit code when triggered in assert"
 ! run_test_script do_test_error_reporting.sh [func_assert] || false
-grep "Error in expect_true(test.sh:.*): 'false' exited with status 1" "$OUT"
+grep "Error in expect_true(test.sh:[[:digit:]]\+): '.*' exited with status 1" "$OUT"
 
 start_test "The error message should identify the source, line, command and exit code when triggered in setup_test_suite"
 ! INLINE=     run_test_script do_test_error_reporting.sh [setup_test_suite] || false

--- a/test/test_inline.sh
+++ b/test/test_inline.sh
@@ -5,7 +5,7 @@ export OUTFILE="$TEST_SCRIPT_DIR"/.test_inline.out
 
 start_test "Inline test failures should display the failed test in the main output"
 OUT="$TEST_SCRIPT_DIR"/.do_test_inline.sh.main.out
-( ! COLOR=no run_test_script do_test_inline.sh >"$OUT" 2>&1 || false )
+( ! COLOR=no VERBOSE= run_test_script do_test_inline.sh >"$OUT" 2>&1 || false )
 diff - "$OUT" <<EOF
 * do_test_inline ok
 * do_test_inline fail


### PR DESCRIPTION
Also generate error reports for syntax errors in eval'ed code, dinstinguished from
a normal error. The code in ,  and  is horrible.